### PR TITLE
Updating ethtool invalid exit status

### DIFF
--- a/jobs/ethtool/templates/post-start.erb
+++ b/jobs/ethtool/templates/post-start.erb
@@ -1,10 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
 set -x
   
-ethtool -G eth0 rx <%= p("rx") %>
-ethtool -G eth0 tx <%= p("tx") %>
-ethtool -G eth0 rx-mini <%= p("rx-mini") %>
-ethtool -G eth0 rx-jumbo <%= p("rx-jumbo") %>
+ethtool -G eth0 rx <%= p("rx") %> || true
+ethtool -G eth0 tx <%= p("tx") %> || true
+ethtool -G eth0 rx-mini <%= p("rx-mini") %> || true
+ethtool -G eth0 rx-jumbo <%= p("rx-jumbo") %> || true
 
 

--- a/jobs/ethtool/templates/pre-start.erb
+++ b/jobs/ethtool/templates/pre-start.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Install ethtool
 cd /var/vcap/packages/ethtool


### PR DESCRIPTION
Updated scripts to ignore exit status of ethtool similar to [bosh-addon-for-tkgi repo](https://github.com/riazvm/bosh-addon-for-tkgi/blob/main/jobs/pre-run-script/templates/bin/post-start.erb#L3-L5)

Forced exit status of ethtool to be ignored if non-zero exit status